### PR TITLE
Update the Pkg in build.zig to build on master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub const pkg = std.build.Pkg{
     .name = "zlog",
-    .path = .{ .path = thisDir() ++ "/src/zlog.zig" },
+    .path = .{ .source = thisDir() ++ "/src/zlog.zig" },
 };
 
 pub fn build(b: *std.build.Builder) void {


### PR DESCRIPTION
If you do not want this change would you be happy to create a new branch where zlog builds on master, like next or dev or something?

I think for some reason the `std.build.Pkg` struct was changed and the `.path` field became `.source`, and it would be nice to have a beta branch if you prefer to support stable Zig.

